### PR TITLE
FIX: Implement PluginInterface methods in Plugin

### DIFF
--- a/src/lib/Plugin.php
+++ b/src/lib/Plugin.php
@@ -34,6 +34,7 @@ use SP\Modules\Web\Plugins\Authenticator\Models\AuthenticatorData;
 use SP\Modules\Web\Plugins\Authenticator\Util\PluginContext;
 use SP\Mvc\Controller\ExtensibleTabControllerInterface;
 use SP\Plugin\PluginBase;
+use SP\Plugin\PluginInterface;
 use SP\Util\Util;
 use SplSubject;
 
@@ -67,6 +68,15 @@ class Plugin extends PluginBase
     public function update(SplSubject $subject)
     {
     }
+    
+    // Implement methods onLoad & upgrade from PluginInterface, otherwise throws an error
+    public function onLoad()
+    {
+    }
+    
+    public function upgrade(string $version, PluginOperation $pluginOperation, $extra = NULL)
+    {
+    }        
 
     /**
      * Inicialización del plugin


### PR DESCRIPTION
Problem:
When installed with Composer, Syspass wouldn't load in browser. Logs showed:
```
PHP Fatal error:  Class SP\\Modules\\Web\\Plugins\\Authenticator\\Plugin contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (SP\\Plugin\\PluginInterface::onLoad, SP\\Plugin\\PluginInterface::upgrade) in /var/www/html/syspass/app/modules/web/plugins/Authenticator/src/lib/Plugin.php on line 45
```
On Centos7, PHP7.1, httpd 2.4

When I implemented the methods, Syspass loaded normally without errors in logs